### PR TITLE
add zindex 10000 to make sure warning is always on top

### DIFF
--- a/maintenanceWarningSnackbar.js
+++ b/maintenanceWarningSnackbar.js
@@ -17,6 +17,7 @@
     left: 12.5%;
     bottom: 30px;
     font-size: 17px;
+    z-index: 10000;
   }
   
   #maintenance-warning-snackbar.show {


### PR DESCRIPTION
Currently the banner is partially visible in situations where other elements have a z-index set. Setting it to z-index: 10000; should solve it in most cases.

<img width="1800" alt="Bildschirmfoto 2024-11-13 um 11 10 56" src="https://github.com/user-attachments/assets/04a15a2e-9791-42bd-9a1d-d05b5952bc42">
